### PR TITLE
Update references to documentation

### DIFF
--- a/src/hellomoon/nft.py
+++ b/src/hellomoon/nft.py
@@ -7,7 +7,7 @@ class NFT:
         self.base_url = MAINNET_BASE_URL
         self.api_key = api_key
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-floorprice-candlesticks
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-floorprice-candlesticks
     def collection_candlesticks(
         self, 
         helloMoonCollectionId: str, 
@@ -25,7 +25,7 @@ class NFT:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-mints-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-mints
     def collection_mint_mapping(
         self, 
         helloMoonCollectionId: str, 
@@ -42,7 +42,7 @@ class NFT:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-name-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-name
     def collection_name_mapping(
         self, 
         helloMoonCollectionId: str, 
@@ -59,7 +59,7 @@ class NFT:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-volatility
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-volatility
     def collection_volatility(
         self, 
         helloMoonCollectionId: str, 
@@ -75,7 +75,7 @@ class NFT:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-listing-status-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-listing-status
     def listing_status(
         self, 
         helloMoonCollectionId: str=None, 
@@ -98,7 +98,7 @@ class NFT:
 
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-listings-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-listings
     def nft_listings(
         self, 
         helloMoonCollectionId: str=None, 
@@ -121,7 +121,7 @@ class NFT:
 
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-mint-information-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-mint-information
     def metaplex_metadata(
         self, 
         nftMint: str=None, 
@@ -139,7 +139,7 @@ class NFT:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-mints-by-owner-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-mints-by-owner
     def mints_by_owner(
         self, 
         nftMint: str=None, 
@@ -158,7 +158,7 @@ class NFT:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-sales-primary-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-sales-primary
     def primary_sales(
         self, 
         nftMint: str=None, 
@@ -180,7 +180,7 @@ class NFT:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-sales-secondary-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-sales-secondary
     def secondary_sales(
         self, 
         nftMint: str=None, 

--- a/src/hellomoon/nft_summary.py
+++ b/src/hellomoon/nft_summary.py
@@ -7,7 +7,7 @@ class NFTSummary:
         self.base_url = MAINNET_BASE_URL
         self.api_key = api_key
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-daily-sales-stats
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-daily-sales-stats
     def collection_daily_sales_stats(
         self, 
         helloMoonCollectionId: str=None, 
@@ -23,7 +23,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-listing-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-listing
     def collection_listing_stats(
         self, 
         helloMoonCollectionId: str=None, 
@@ -40,7 +40,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-overlap-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-overlap
     def collection_overlap(
         self, 
         helloMoonCollectionId: str, 
@@ -57,7 +57,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-ownership-cumulative-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-ownership-cumulative
     def cumulative_nft_owners_over_time(
         self, 
         day: str, 
@@ -73,7 +73,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-ownership-current-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-ownership-current
     def collection_current_owners(
         self, 
         helloMoonCollectionId: str, 
@@ -89,7 +89,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-ownership-historical-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-ownership-historical
     def collection_distinct_owners_over_time(
         self, 
         helloMoonCollectionId: str, 
@@ -106,7 +106,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-ownership-holding-period-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-ownership-holding-period
     def collection_holding_period(
         self, 
         helloMoonCollectionId: str, 
@@ -123,7 +123,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-ownership-top-holders-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-ownership-top-holders
     def collection_top_holders(
         self, 
         helloMoonCollectionId: str, 
@@ -142,7 +142,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-program-usage-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-program-usage
     def collection_program_usage(
         self, 
         helloMoonCollectionId: str, 
@@ -158,7 +158,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-stats-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-stats
     def collection_stats_with_floor_price(
         self, 
         helloMoonCollectionId: str=None,
@@ -176,7 +176,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-collection-stats-primary-sales-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-collection-stats-primary-sales
     def collection_mint_stats(
         self, 
         helloMoonCollectionId: str,
@@ -213,7 +213,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-market-stats-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-market-stats
     def marketplace_stats(
         self, 
         market: List[str],
@@ -229,7 +229,7 @@ class NFTSummary:
         url = self.base_url + path
         return _make_post_request(url, self.api_key, payload)
 
-    # https://hellomoon.readme.io/reference/post_v0-nft-sales-per-market-daily-1
+    # https://docs.hellomoon.io/reference/post_v0-nft-sales-per-market-daily
     def market_sales_over_time(
         self, 
         market: List[str],


### PR DESCRIPTION
Looks like documentation was moved to its own subdomain at [docs.hellomoon.io](https://docs.hellomoon.io/). Updated comments to reflect the change.